### PR TITLE
Fix footer rotation text

### DIFF
--- a/src/ui/astro/sections/Footer.astro
+++ b/src/ui/astro/sections/Footer.astro
@@ -10,14 +10,20 @@ import Social from './Social.astro'
             <article class="text-xl font-medium flex justify-center">
                 <div class=" dark:border-zinc-700  bg-slate-50/[0.7] shadow-md dark:bg-zinc-900/[0.7] rounded-xl p-6 max-w-full overflow-hidden">
                     <span>Interested in </span>
-                    <FlipWords client:visible words={['changing the world?',
-                        'making a dent in the universe?',
-                        'in work that is mysterious and important?',
-                        'building valuable products?',
-                        'solving meaningful problems?']} duration={4000}></FlipWords>
+                    <FlipWords
+                        client:visible
+                        words={[
+                            'changing the world?',
+                            'making a dent in the universe?',
+                            'work that is mysterious and important?',
+                            'building valuable products?',
+                            'solving meaningful problems?',
+                        ]}
+                        duration={4000}
+                        className="whitespace-nowrap"
+                    ></FlipWords>
                     <br/>
                     <div class="text-base pt-2">I am, <a href="mailto:hello@alexwhiteside.dev"> let's talk</a>.</div>
-                    </span>
 
                 </div>
 


### PR DESCRIPTION
## Summary
- remove duplicate `in` from rotating footer text
- keep footer rotation text on one line
- drop stray closing `span`

## Testing
- `npm run lint` *(fails: formatter reports diff)*

------
https://chatgpt.com/codex/tasks/task_e_68637aae207c832c846afd8b0b5a654b